### PR TITLE
feat: support multiple listen addresses

### DIFF
--- a/.github/workflows/test-socks-proxy.yaml
+++ b/.github/workflows/test-socks-proxy.yaml
@@ -38,7 +38,9 @@ jobs:
           main:
             workers: 2
             port: 1080
-            listen-address: '127.0.0.1'
+            listen-address:
+              - '127.0.0.1'
+              - '::1'
             udp-port: 0  # Disable UDP for testing
             listen-ipv6-only: false
             bind-address: ''
@@ -58,12 +60,16 @@ jobs:
           # Wait for server to start
           sleep 2
 
-          # Test SOCKS5 with curl
+          # Test SOCKS5 on IPv4 listener
           curl -v --socks5 127.0.0.1:1080 https://ifconfig.me/ip
-          # Test with explicit SOCKS5 hostname resolution
+          # Test SOCKS5 hostname resolution on IPv4 listener
           curl -v --socks5-hostname 127.0.0.1:1080 https://ifconfig.me/ip
+          # Test SOCKS5 on IPv6 listener
+          curl -v --socks5 [::1]:1080 https://ifconfig.me/ip
+          # Test SOCKS5 hostname resolution on IPv6 listener
+          curl -v --socks5-hostname [::1]:1080 https://ifconfig.me/ip
 
-          # Test SOCKS4 with curl
+          # Test SOCKS4 on IPv4 listener
           curl -v --socks4 127.0.0.1:1080 https://ifconfig.me/ip
 
           if [ -f server.pid ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 HevSocks5Server.xcframework
 .vscode/
 .private.key
+/.cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/ssciwr/clang-format-hook
+    rev: v16.0.2
+    hooks:
+      - id: clang-format
+        types_or: [c, c++]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ main:
   port: 1080
   # Listen address (ipv4|ipv6)
   # Can be a single address or a YAML list for multiple addresses.
-  # Maximum number of listen addresses: 16
+  # Maximum number of listen addresses: HEV_CONFIG_MAX_LISTEN_ADDRESSES (16)
   listen-address:
     - '::'
     - '127.0.0.1'
@@ -109,7 +109,8 @@ main:
 # limit-nofile: 65535
 ```
 
-`listen-address` supports up to 16 addresses. If only one address is needed,
+`listen-address` supports up to `HEV_CONFIG_MAX_LISTEN_ADDRESSES` entries
+(currently 16). If only one address is needed,
 you can still use the scalar form: `listen-address: '::'`.
 
 ### Authentication file

--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ main:
   # Listen port
   port: 1080
   # Listen address (ipv4|ipv6)
-  listen-address: '::'
+  # Can be a single address or a YAML list for multiple addresses.
+  # Maximum number of listen addresses: 16
+  listen-address:
+    - '::'
+    - '127.0.0.1'
   # UDP listen port (0: random, a-b: range)
 # udp-port: 0
   # UDP listen address (ipv4|ipv6)
@@ -104,6 +108,9 @@ main:
   # If present, set rlimit nofile; else use default value
 # limit-nofile: 65535
 ```
+
+`listen-address` supports up to 16 addresses. If only one address is needed,
+you can still use the scalar form: `listen-address: '::'`.
 
 ### Authentication file
 

--- a/conf/main.yml
+++ b/conf/main.yml
@@ -7,7 +7,7 @@ main:
   port: 1080
   # Listen address (ipv4|ipv6)
   # Can be a single address or a YAML list for multiple addresses.
-  # Maximum number of listen addresses: 16
+  # Maximum number of listen addresses: HEV_CONFIG_MAX_LISTEN_ADDRESSES (16)
   listen-address:
     - '::'
   # UDP listen port (0: random, a-b: range)

--- a/conf/main.yml
+++ b/conf/main.yml
@@ -6,13 +6,9 @@ main:
   # Listen port
   port: 1080
   # Listen address (ipv4|ipv6)
-  # Can be a single address or a comma-separated list:
-  listen-address: '::'
-  # Or as a YAML list for multiple addresses:
-  # listen-address:
-  #   - '127.0.0.1'
-  #   - '::1'
-  #   - '192.168.1.1'
+  # Can be a single address or a YAML list for multiple addresses:
+  listen-address:
+    - '::'
   # UDP listen port (0: random, a-b: range)
 # udp-port: 0
   # UDP listen address (ipv4|ipv6)

--- a/conf/main.yml
+++ b/conf/main.yml
@@ -6,7 +6,8 @@ main:
   # Listen port
   port: 1080
   # Listen address (ipv4|ipv6)
-  # Can be a single address or a YAML list for multiple addresses:
+  # Can be a single address or a YAML list for multiple addresses.
+  # Maximum number of listen addresses: 16
   listen-address:
     - '::'
   # UDP listen port (0: random, a-b: range)

--- a/conf/main.yml
+++ b/conf/main.yml
@@ -6,7 +6,13 @@ main:
   # Listen port
   port: 1080
   # Listen address (ipv4|ipv6)
+  # Can be a single address or a comma-separated list:
   listen-address: '::'
+  # Or as a YAML list for multiple addresses:
+  # listen-address:
+  #   - '127.0.0.1'
+  #   - '::1'
+  #   - '192.168.1.1'
   # UDP listen port (0: random, a-b: range)
 # udp-port: 0
   # UDP listen address (ipv4|ipv6)

--- a/src/hev-config-const.h
+++ b/src/hev-config-const.h
@@ -14,4 +14,6 @@
 #define MINOR_VERSION (11)
 #define MICRO_VERSION (2)
 
+#define HEV_CONFIG_MAX_LISTEN_ADDRESSES (16)
+
 #endif /* __HEV_CONFIG_CONST_H__ */

--- a/src/hev-config.c
+++ b/src/hev-config.c
@@ -17,11 +17,12 @@
 
 #include "hev-logger.h"
 #include "hev-config.h"
+#include "hev-config-const.h"
 
 static unsigned int workers;
 static int listen_ipv6_only;
 static unsigned int listen_address_count;
-static char listen_addresses[16][256];
+static char listen_addresses[HEV_CONFIG_MAX_LISTEN_ADDRESSES][256];
 static char listen_port[8];
 static char udp_listen_address[256];
 static char udp_public_address[2][256];
@@ -53,8 +54,9 @@ hev_config_parse_listen_address_node (yaml_document_t *doc, yaml_node_t *node)
 
     /* Support scalar for single address (backward compatible) */
     if (YAML_SCALAR_NODE == node->type) {
-        if (listen_address_count >= 16) {
-            fprintf (stderr, "main.listen-address supports at most 16 values!\n");
+        if (listen_address_count >= HEV_CONFIG_MAX_LISTEN_ADDRESSES) {
+            fprintf (stderr, "main.listen-address supports at most %u values!\n",
+                     HEV_CONFIG_MAX_LISTEN_ADDRESSES);
             return -1;
         }
 
@@ -74,9 +76,10 @@ hev_config_parse_listen_address_node (yaml_document_t *doc, yaml_node_t *node)
             if (!val_node || YAML_SCALAR_NODE != val_node->type)
                 return -1;
 
-            if (listen_address_count >= 16) {
+            if (listen_address_count >= HEV_CONFIG_MAX_LISTEN_ADDRESSES) {
                 fprintf (stderr,
-                         "main.listen-address supports at most 16 values!\n");
+                         "main.listen-address supports at most %u values!\n",
+                         HEV_CONFIG_MAX_LISTEN_ADDRESSES);
                 return -1;
             }
 

--- a/src/hev-config.c
+++ b/src/hev-config.c
@@ -53,12 +53,15 @@ hev_config_parse_listen_address_node (yaml_document_t *doc, yaml_node_t *node)
 
     /* Support scalar for single address (backward compatible) */
     if (YAML_SCALAR_NODE == node->type) {
-        if (listen_address_count < 16) {
-            strncpy (listen_addresses[listen_address_count],
-                     (const char *)node->data.scalar.value, 255);
-            listen_addresses[listen_address_count][255] = '\0';
-            listen_address_count++;
+        if (listen_address_count >= 16) {
+            fprintf (stderr, "main.listen-address supports at most 16 values!\n");
+            return -1;
         }
+
+        strncpy (listen_addresses[listen_address_count],
+                 (const char *)node->data.scalar.value, 255);
+        listen_addresses[listen_address_count][255] = '\0';
+        listen_address_count++;
         return 0;
     }
 
@@ -71,12 +74,16 @@ hev_config_parse_listen_address_node (yaml_document_t *doc, yaml_node_t *node)
             if (!val_node || YAML_SCALAR_NODE != val_node->type)
                 return -1;
 
-            if (listen_address_count < 16) {
-                strncpy (listen_addresses[listen_address_count],
-                         (const char *)val_node->data.scalar.value, 255);
-                listen_addresses[listen_address_count][255] = '\0';
-                listen_address_count++;
+            if (listen_address_count >= 16) {
+                fprintf (stderr,
+                         "main.listen-address supports at most 16 values!\n");
+                return -1;
             }
+
+            strncpy (listen_addresses[listen_address_count],
+                     (const char *)val_node->data.scalar.value, 255);
+            listen_addresses[listen_address_count][255] = '\0';
+            listen_address_count++;
         }
         if (listen_address_count == 0)
             return -1;

--- a/src/hev-config.c
+++ b/src/hev-config.c
@@ -48,28 +48,42 @@ static unsigned int socket_mark;
 static int
 hev_config_parse_listen_address_node (yaml_document_t *doc, yaml_node_t *node)
 {
-    if (!node || YAML_SEQUENCE_NODE != node->type)
+    if (!node)
         return -1;
 
-    yaml_node_item_t *item;
-    for (item = node->data.sequence.items.start;
-         item < node->data.sequence.items.top; item++) {
-        yaml_node_t *val_node = yaml_document_get_node (doc, *item);
-        if (!val_node || YAML_SCALAR_NODE != val_node->type)
-            return -1;
-
+    /* Support scalar for single address (backward compatible) */
+    if (YAML_SCALAR_NODE == node->type) {
         if (listen_address_count < 16) {
             strncpy (listen_addresses[listen_address_count],
-                     (const char *)val_node->data.scalar.value, 255);
+                     (const char *)node->data.scalar.value, 255);
             listen_addresses[listen_address_count][255] = '\0';
             listen_address_count++;
         }
+        return 0;
     }
 
-    if (listen_address_count == 0)
-        return -1;
+    /* Support sequence for multiple addresses */
+    if (YAML_SEQUENCE_NODE == node->type) {
+        yaml_node_item_t *item;
+        for (item = node->data.sequence.items.start;
+             item < node->data.sequence.items.top; item++) {
+            yaml_node_t *val_node = yaml_document_get_node (doc, *item);
+            if (!val_node || YAML_SCALAR_NODE != val_node->type)
+                return -1;
 
-    return 0;
+            if (listen_address_count < 16) {
+                strncpy (listen_addresses[listen_address_count],
+                         (const char *)val_node->data.scalar.value, 255);
+                listen_addresses[listen_address_count][255] = '\0';
+                listen_address_count++;
+            }
+        }
+        if (listen_address_count == 0)
+            return -1;
+        return 0;
+    }
+
+    return -1;
 }
 
 static int
@@ -108,7 +122,7 @@ hev_config_parse_main (yaml_document_t *doc, yaml_node_t *base)
         if (!node)
             break;
 
-        /* Handle listen-address - must be a sequence (list) */
+        /* Handle listen-address - scalar (single) or sequence (multiple) */
         if (0 == strcmp (key, "listen-address")) {
             if (hev_config_parse_listen_address_node (doc, node) < 0)
                 return -1;

--- a/src/hev-config.c
+++ b/src/hev-config.c
@@ -20,7 +20,8 @@
 
 static unsigned int workers;
 static int listen_ipv6_only;
-static char listen_address[256];
+static unsigned int listen_address_count;
+static char listen_addresses[16][256];
 static char listen_port[8];
 static char udp_listen_address[256];
 static char udp_public_address[2][256];
@@ -45,10 +46,76 @@ static int addr_family = HEV_SOCKS5_ADDR_FAMILY_UNSPEC;
 static unsigned int socket_mark;
 
 static int
+hev_config_parse_listen_address_value (const char *value)
+{
+    char *addr_str;
+    char *token;
+    char *saveptr;
+
+    if (!value || value[0] == '\0')
+        return -1;
+
+    addr_str = strdup (value);
+    if (!addr_str)
+        return -1;
+
+    token = strtok_r (addr_str, ",", &saveptr);
+    while (token && listen_address_count < 16) {
+        while (*token == ' ' || *token == '\t')
+            token++;
+
+        if (*token != '\0') {
+            strncpy (listen_addresses[listen_address_count], token, 255);
+            listen_addresses[listen_address_count][255] = '\0';
+            listen_address_count++;
+        }
+
+        token = strtok_r (NULL, ",", &saveptr);
+    }
+
+    free (addr_str);
+
+    if (listen_address_count == 0)
+        return -1;
+
+    return 0;
+}
+
+static int
+hev_config_parse_listen_address_node (yaml_document_t *doc, yaml_node_t *node)
+{
+    if (!node)
+        return -1;
+
+    if (YAML_SCALAR_NODE == node->type) {
+        return hev_config_parse_listen_address_value ((const char *)node->data.scalar.value);
+    } else if (YAML_SEQUENCE_NODE == node->type) {
+        yaml_node_item_t *item;
+        for (item = node->data.sequence.items.start;
+             item < node->data.sequence.items.top; item++) {
+            yaml_node_t *val_node = yaml_document_get_node (doc, *item);
+            if (!val_node || YAML_SCALAR_NODE != val_node->type)
+                return -1;
+
+            if (listen_address_count < 16) {
+                strncpy (listen_addresses[listen_address_count],
+                         (const char *)val_node->data.scalar.value, 255);
+                listen_addresses[listen_address_count][255] = '\0';
+                listen_address_count++;
+            }
+        }
+        if (listen_address_count == 0)
+            return -1;
+        return 0;
+    }
+
+    return -1;
+}
+
+static int
 hev_config_parse_main (yaml_document_t *doc, yaml_node_t *base)
 {
     yaml_node_pair_t *pair;
-    const char *addr = NULL;
     const char *port = NULL;
     const char *mark = NULL;
     const char *udp_addr = NULL;
@@ -78,7 +145,18 @@ hev_config_parse_main (yaml_document_t *doc, yaml_node_t *base)
         key = (const char *)node->data.scalar.value;
 
         node = yaml_document_get_node (doc, pair->value);
-        if (!node || YAML_SCALAR_NODE != node->type)
+        if (!node)
+            break;
+
+        /* Handle listen-address specially - can be scalar or sequence */
+        if (0 == strcmp (key, "listen-address")) {
+            if (hev_config_parse_listen_address_node (doc, node) < 0)
+                return -1;
+            continue;
+        }
+
+        /* All other values must be scalars */
+        if (YAML_SCALAR_NODE != node->type)
             break;
         value = (const char *)node->data.scalar.value;
 
@@ -86,8 +164,6 @@ hev_config_parse_main (yaml_document_t *doc, yaml_node_t *base)
             workers = strtoul (value, NULL, 10);
         else if (0 == strcmp (key, "port"))
             port = value;
-        else if (0 == strcmp (key, "listen-address"))
-            addr = value;
         else if (0 == strcmp (key, "udp-port"))
             udp_port = value;
         else if (0 == strcmp (key, "udp-listen-address"))
@@ -122,8 +198,8 @@ hev_config_parse_main (yaml_document_t *doc, yaml_node_t *base)
         return -1;
     }
 
-    if (!addr) {
-        fprintf (stderr, "Can't found main.listen-address!\n");
+    if (listen_address_count == 0) {
+        fprintf (stderr, "Can't found main.listen-address or main.listen-addresses!\n");
         return -1;
     }
 
@@ -135,7 +211,6 @@ hev_config_parse_main (yaml_document_t *doc, yaml_node_t *base)
 #endif
 
     strncpy (listen_port, port, 8 - 1);
-    strncpy (listen_address, addr, 256 - 1);
 
     if (udp_port) {
         unsigned int beg = 0, end = 0;
@@ -420,9 +495,19 @@ hev_config_get_workers (void)
 }
 
 const char *
-hev_config_get_listen_address (void)
+hev_config_get_listen_address (unsigned int *count)
 {
-    return listen_address;
+    if (count)
+        *count = listen_address_count;
+    return listen_addresses[0];
+}
+
+const char *
+hev_config_get_listen_address_at (unsigned int index)
+{
+    if (index >= listen_address_count)
+        return NULL;
+    return listen_addresses[index];
 }
 
 const char *

--- a/src/hev-config.c
+++ b/src/hev-config.c
@@ -173,7 +173,8 @@ hev_config_parse_main (yaml_document_t *doc, yaml_node_t *base)
     }
 
     if (listen_address_count == 0) {
-        fprintf (stderr, "Can't found main.listen-address or main.listen-addresses!\n");
+        fprintf (stderr,
+                 "Can't found main.listen-address or main.listen-addresses!\n");
         return -1;
     }
 

--- a/src/hev-config.c
+++ b/src/hev-config.c
@@ -46,70 +46,30 @@ static int addr_family = HEV_SOCKS5_ADDR_FAMILY_UNSPEC;
 static unsigned int socket_mark;
 
 static int
-hev_config_parse_listen_address_value (const char *value)
+hev_config_parse_listen_address_node (yaml_document_t *doc, yaml_node_t *node)
 {
-    char *addr_str;
-    char *token;
-    char *saveptr;
-
-    if (!value || value[0] == '\0')
+    if (!node || YAML_SEQUENCE_NODE != node->type)
         return -1;
 
-    addr_str = strdup (value);
-    if (!addr_str)
-        return -1;
+    yaml_node_item_t *item;
+    for (item = node->data.sequence.items.start;
+         item < node->data.sequence.items.top; item++) {
+        yaml_node_t *val_node = yaml_document_get_node (doc, *item);
+        if (!val_node || YAML_SCALAR_NODE != val_node->type)
+            return -1;
 
-    token = strtok_r (addr_str, ",", &saveptr);
-    while (token && listen_address_count < 16) {
-        while (*token == ' ' || *token == '\t')
-            token++;
-
-        if (*token != '\0') {
-            strncpy (listen_addresses[listen_address_count], token, 255);
+        if (listen_address_count < 16) {
+            strncpy (listen_addresses[listen_address_count],
+                     (const char *)val_node->data.scalar.value, 255);
             listen_addresses[listen_address_count][255] = '\0';
             listen_address_count++;
         }
-
-        token = strtok_r (NULL, ",", &saveptr);
     }
-
-    free (addr_str);
 
     if (listen_address_count == 0)
         return -1;
 
     return 0;
-}
-
-static int
-hev_config_parse_listen_address_node (yaml_document_t *doc, yaml_node_t *node)
-{
-    if (!node)
-        return -1;
-
-    if (YAML_SCALAR_NODE == node->type) {
-        return hev_config_parse_listen_address_value ((const char *)node->data.scalar.value);
-    } else if (YAML_SEQUENCE_NODE == node->type) {
-        yaml_node_item_t *item;
-        for (item = node->data.sequence.items.start;
-             item < node->data.sequence.items.top; item++) {
-            yaml_node_t *val_node = yaml_document_get_node (doc, *item);
-            if (!val_node || YAML_SCALAR_NODE != val_node->type)
-                return -1;
-
-            if (listen_address_count < 16) {
-                strncpy (listen_addresses[listen_address_count],
-                         (const char *)val_node->data.scalar.value, 255);
-                listen_addresses[listen_address_count][255] = '\0';
-                listen_address_count++;
-            }
-        }
-        if (listen_address_count == 0)
-            return -1;
-        return 0;
-    }
-
-    return -1;
 }
 
 static int
@@ -148,7 +108,7 @@ hev_config_parse_main (yaml_document_t *doc, yaml_node_t *base)
         if (!node)
             break;
 
-        /* Handle listen-address specially - can be scalar or sequence */
+        /* Handle listen-address - must be a sequence (list) */
         if (0 == strcmp (key, "listen-address")) {
             if (hev_config_parse_listen_address_node (doc, node) < 0)
                 return -1;

--- a/src/hev-config.c
+++ b/src/hev-config.c
@@ -55,7 +55,8 @@ hev_config_parse_listen_address_node (yaml_document_t *doc, yaml_node_t *node)
     /* Support scalar for single address (backward compatible) */
     if (YAML_SCALAR_NODE == node->type) {
         if (listen_address_count >= HEV_CONFIG_MAX_LISTEN_ADDRESSES) {
-            fprintf (stderr, "main.listen-address supports at most %u values!\n",
+            fprintf (stderr,
+                     "main.listen-address supports at most %u values!\n",
                      HEV_CONFIG_MAX_LISTEN_ADDRESSES);
             return -1;
         }

--- a/src/hev-config.h
+++ b/src/hev-config.h
@@ -17,7 +17,8 @@ void hev_config_fini (void);
 
 unsigned int hev_config_get_workers (void);
 
-const char *hev_config_get_listen_address (void);
+const char *hev_config_get_listen_address (unsigned int *count);
+const char *hev_config_get_listen_address_at (unsigned int index);
 const char *hev_config_get_listen_port (void);
 const char *hev_config_get_udp_listen_address (void);
 int hev_config_get_udp_listen_port (void);

--- a/src/hev-socket-factory.c
+++ b/src/hev-socket-factory.c
@@ -23,18 +23,25 @@
 
 struct _HevSocketFactory
 {
-    struct sockaddr_in6 addr;
+    struct sockaddr_in6 addrs[16];
     int ipv6_only;
+    unsigned int addr_count;
+    unsigned int current_addr;
     int fd;
 };
 
 HevSocketFactory *
-hev_socket_factory_new (const char *addr, const char *port, int ipv6_only)
+hev_socket_factory_new (const char **addrs, unsigned int addr_count,
+                        const char *port, int ipv6_only)
 {
     HevSocketFactory *self;
+    unsigned int i;
     int res;
 
     LOG_D ("socket factory new");
+
+    if (!addrs || addr_count == 0 || addr_count > 16)
+        return NULL;
 
     self = hev_malloc0 (sizeof (HevSocketFactory));
     if (!self) {
@@ -42,14 +49,18 @@ hev_socket_factory_new (const char *addr, const char *port, int ipv6_only)
         return NULL;
     }
 
-    res = hev_netaddr_resolve (&self->addr, addr, port);
-    if (res < 0) {
-        LOG_E ("socket factory resolve");
-        hev_free (self);
-        return NULL;
+    for (i = 0; i < addr_count; i++) {
+        res = hev_netaddr_resolve (&self->addrs[i], addrs[i], port);
+        if (res < 0) {
+            LOG_E ("socket factory resolve");
+            hev_free (self);
+            return NULL;
+        }
     }
 
     self->ipv6_only = ipv6_only;
+    self->addr_count = addr_count;
+    self->current_addr = 0;
     self->fd = -1;
 
     return self;
@@ -71,11 +82,18 @@ hev_socket_factory_get (HevSocketFactory *self)
     int one = 1;
     int res;
     int fd;
+    unsigned int idx;
 
     LOG_D ("socket factory get");
 
+    /* Return existing fd if already created */
     if (self->fd >= 0)
         return dup (self->fd);
+
+    /* Get current address index */
+    idx = self->current_addr;
+    if (idx >= self->addr_count)
+        return -1;
 
     fd = hev_task_io_socket_socket (AF_INET6, SOCK_STREAM, 0);
     if (fd < 0) {
@@ -103,7 +121,7 @@ hev_socket_factory_get (HevSocketFactory *self)
         goto exit_close;
     }
 
-    res = bind (fd, (struct sockaddr *)&self->addr, sizeof (self->addr));
+    res = bind (fd, (struct sockaddr *)&self->addrs[idx], sizeof (self->addrs[idx]));
     if (res < 0) {
         LOG_E ("socket factory bind");
         goto exit_close;
@@ -114,6 +132,9 @@ hev_socket_factory_get (HevSocketFactory *self)
         LOG_E ("socket factory listen");
         goto exit_close;
     }
+
+    /* Move to next address for subsequent calls */
+    self->current_addr++;
 
     return fd;
 

--- a/src/hev-socket-factory.c
+++ b/src/hev-socket-factory.c
@@ -24,10 +24,9 @@
 struct _HevSocketFactory
 {
     struct sockaddr_in6 addrs[16];
+    int fds[16];
     int ipv6_only;
     unsigned int addr_count;
-    unsigned int current_addr;
-    int fd;
 };
 
 HevSocketFactory *
@@ -60,8 +59,8 @@ hev_socket_factory_new (const char **addrs, unsigned int addr_count,
 
     self->ipv6_only = ipv6_only;
     self->addr_count = addr_count;
-    self->current_addr = 0;
-    self->fd = -1;
+    for (i = 0; i < addr_count; i++)
+        self->fds[i] = -1;
 
     return self;
 }
@@ -69,31 +68,37 @@ hev_socket_factory_new (const char **addrs, unsigned int addr_count,
 void
 hev_socket_factory_destroy (HevSocketFactory *self)
 {
+    unsigned int i;
+
     LOG_D ("socket factory destroy");
 
-    if (self->fd >= 0)
-        close (self->fd);
+    for (i = 0; i < self->addr_count; i++) {
+        if (self->fds[i] >= 0)
+            close (self->fds[i]);
+    }
     hev_free (self);
 }
 
+unsigned int
+hev_socket_factory_get_count (HevSocketFactory *self)
+{
+    return self->addr_count;
+}
+
 int
-hev_socket_factory_get (HevSocketFactory *self)
+hev_socket_factory_get (HevSocketFactory *self, unsigned int idx)
 {
     int one = 1;
     int res;
     int fd;
-    unsigned int idx;
 
     LOG_D ("socket factory get");
 
-    /* Return existing fd if already created */
-    if (self->fd >= 0)
-        return dup (self->fd);
-
-    /* Get current address index */
-    idx = self->current_addr;
     if (idx >= self->addr_count)
         return -1;
+
+    if (self->fds[idx] >= 0)
+        return dup (self->fds[idx]);
 
     fd = hev_task_io_socket_socket (AF_INET6, SOCK_STREAM, 0);
     if (fd < 0) {
@@ -111,8 +116,6 @@ hev_socket_factory_get (HevSocketFactory *self)
 #ifdef SO_REUSEPORT
     res = setsockopt (fd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof (one));
 #endif
-    if (res < 0 && self->fd < 0)
-        self->fd = dup (fd);
 
     res = setsockopt (fd, IPPROTO_IPV6, IPV6_V6ONLY, &self->ipv6_only,
                       sizeof (self->ipv6_only));
@@ -134,8 +137,9 @@ hev_socket_factory_get (HevSocketFactory *self)
         goto exit_close;
     }
 
-    /* Move to next address for subsequent calls */
-    self->current_addr++;
+    self->fds[idx] = dup (fd);
+    if (self->fds[idx] < 0)
+        goto exit_close;
 
     return fd;
 

--- a/src/hev-socket-factory.c
+++ b/src/hev-socket-factory.c
@@ -18,13 +18,14 @@
 
 #include "hev-misc.h"
 #include "hev-logger.h"
+#include "hev-config-const.h"
 
 #include "hev-socket-factory.h"
 
 struct _HevSocketFactory
 {
-    struct sockaddr_in6 addrs[16];
-    int fds[16];
+    struct sockaddr_in6 addrs[HEV_CONFIG_MAX_LISTEN_ADDRESSES];
+    int fds[HEV_CONFIG_MAX_LISTEN_ADDRESSES];
     int ipv6_only;
     unsigned int addr_count;
 };
@@ -39,7 +40,8 @@ hev_socket_factory_new (const char **addrs, unsigned int addr_count,
 
     LOG_D ("socket factory new");
 
-    if (!addrs || addr_count == 0 || addr_count > 16)
+    if (!addrs || addr_count == 0 ||
+        addr_count > HEV_CONFIG_MAX_LISTEN_ADDRESSES)
         return NULL;
 
     self = hev_malloc0 (sizeof (HevSocketFactory));

--- a/src/hev-socket-factory.c
+++ b/src/hev-socket-factory.c
@@ -121,7 +121,8 @@ hev_socket_factory_get (HevSocketFactory *self)
         goto exit_close;
     }
 
-    res = bind (fd, (struct sockaddr *)&self->addrs[idx], sizeof (self->addrs[idx]));
+    res = bind (fd, (struct sockaddr *)&self->addrs[idx],
+                sizeof (self->addrs[idx]));
     if (res < 0) {
         LOG_E ("socket factory bind");
         goto exit_close;

--- a/src/hev-socket-factory.h
+++ b/src/hev-socket-factory.h
@@ -12,7 +12,8 @@
 
 typedef struct _HevSocketFactory HevSocketFactory;
 
-HevSocketFactory *hev_socket_factory_new (const char **addrs, unsigned int addr_count,
+HevSocketFactory *hev_socket_factory_new (const char **addrs,
+                                          unsigned int addr_count,
                                           const char *port, int ipv6_only);
 void hev_socket_factory_destroy (HevSocketFactory *self);
 

--- a/src/hev-socket-factory.h
+++ b/src/hev-socket-factory.h
@@ -17,6 +17,7 @@ HevSocketFactory *hev_socket_factory_new (const char **addrs,
                                           const char *port, int ipv6_only);
 void hev_socket_factory_destroy (HevSocketFactory *self);
 
-int hev_socket_factory_get (HevSocketFactory *self);
+unsigned int hev_socket_factory_get_count (HevSocketFactory *self);
+int hev_socket_factory_get (HevSocketFactory *self, unsigned int index);
 
 #endif /* __HEV_SOCKET_FACTORY_H__ */

--- a/src/hev-socket-factory.h
+++ b/src/hev-socket-factory.h
@@ -12,8 +12,8 @@
 
 typedef struct _HevSocketFactory HevSocketFactory;
 
-HevSocketFactory *hev_socket_factory_new (const char *addr, const char *port,
-                                          int ipv6_only);
+HevSocketFactory *hev_socket_factory_new (const char **addrs, unsigned int addr_count,
+                                          const char *port, int ipv6_only);
 void hev_socket_factory_destroy (HevSocketFactory *self);
 
 int hev_socket_factory_get (HevSocketFactory *self);

--- a/src/hev-socks5-proxy.c
+++ b/src/hev-socks5-proxy.c
@@ -27,13 +27,57 @@
 
 #include "hev-socks5-proxy.h"
 
-static int listen_fd = -1;
 static unsigned int workers;
 
 static HevTask *task;
 static pthread_t *work_threads;
 static HevSocketFactory *factory;
 static HevSocks5Worker **worker_list;
+
+static int *
+hev_socks5_proxy_dup_listen_fds (unsigned int *fd_count)
+{
+    unsigned int count;
+    unsigned int i;
+    int *fds;
+
+    count = hev_socket_factory_get_count (factory);
+    fds = hev_malloc0 (sizeof (int) * count);
+    if (!fds)
+        return NULL;
+
+    for (i = 0; i < count; i++) {
+        fds[i] = hev_socket_factory_get (factory, i);
+        if (fds[i] < 0) {
+            while (i > 0) {
+                i--;
+                close (fds[i]);
+            }
+            hev_free (fds);
+            return NULL;
+        }
+    }
+
+    *fd_count = count;
+
+    return fds;
+}
+
+static void
+hev_socks5_proxy_free_listen_fds (int *fds, unsigned int fd_count)
+{
+    unsigned int i;
+
+    if (!fds)
+        return;
+
+    for (i = 0; i < fd_count; i++) {
+        if (fds[i] >= 0)
+            close (fds[i]);
+    }
+
+    hev_free (fds);
+}
 
 static void
 hev_socks5_proxy_load_file (HevSocks5Authenticator *auth, const char *file)
@@ -213,23 +257,28 @@ static void *
 work_thread_handler (void *data)
 {
     HevSocks5Worker **worker = data;
+    unsigned int fd_count = 0;
+    int *fds = NULL;
     int res;
-    int fd;
 
     if (hev_task_system_init () < 0) {
         LOG_E ("socks5 proxy worker task system");
         goto exit;
     }
 
-    fd = hev_socket_factory_get (factory);
-    if (fd < 0) {
-        LOG_E ("socks5 proxy worker socket");
+    fds = hev_socks5_proxy_dup_listen_fds (&fd_count);
+    if (!fds) {
+        LOG_E ("socks5 proxy worker sockets");
         goto free;
     }
 
-    res = hev_socks5_worker_init (*worker, fd);
+    res = hev_socks5_worker_init (*worker, fds, fd_count);
+    hev_free (fds);
+    fds = NULL;
     if (res < 0) {
         LOG_E ("socks5 proxy worker init");
+        hev_socks5_worker_destroy (*worker);
+        *worker = NULL;
         goto free;
     }
 
@@ -241,8 +290,7 @@ work_thread_handler (void *data)
     *worker = NULL;
 
 free:
-    if (fd >= 0)
-        close (fd);
+    hev_socks5_proxy_free_listen_fds (fds, fd_count);
     hev_task_system_fini ();
 exit:
     return NULL;
@@ -251,24 +299,31 @@ exit:
 static void
 hev_socks5_proxy_task_entry (void *data)
 {
+    unsigned int fd_count = 0;
+    int *fds = NULL;
     int res;
     int i;
 
     LOG_D ("socks5 proxy task run");
 
-    listen_fd = hev_socket_factory_get (factory);
-    if (listen_fd < 0)
+    fds = hev_socks5_proxy_dup_listen_fds (&fd_count);
+    if (!fds)
         return;
 
     worker_list[0] = hev_socks5_worker_new ();
     if (!worker_list[0]) {
         LOG_E ("socks5 proxy worker");
+        hev_socks5_proxy_free_listen_fds (fds, fd_count);
         return;
     }
 
-    res = hev_socks5_worker_init (worker_list[0], listen_fd);
+    res = hev_socks5_worker_init (worker_list[0], fds, fd_count);
+    hev_free (fds);
+    fds = NULL;
     if (res < 0) {
         LOG_E ("socks5 proxy worker init");
+        hev_socks5_worker_destroy (worker_list[0]);
+        worker_list[0] = NULL;
         return;
     }
 
@@ -298,9 +353,6 @@ hev_socks5_proxy_run (void)
     hev_task_run (task, hev_socks5_proxy_task_entry, NULL);
 
     hev_task_system_run ();
-
-    if (listen_fd >= 0)
-        close (listen_fd);
 
     if (worker_list[0]) {
         int i;

--- a/src/hev-socks5-proxy.c
+++ b/src/hev-socks5-proxy.c
@@ -133,6 +133,10 @@ sigint_handler (int signum)
 int
 hev_socks5_proxy_init (void)
 {
+    unsigned int addr_count = 0;
+    const char **addrs;
+    unsigned int i;
+
     LOG_D ("socks5 proxy init");
 
     if (hev_task_system_init () < 0) {
@@ -159,9 +163,21 @@ hev_socks5_proxy_init (void)
         goto exit;
     }
 
-    factory = hev_socket_factory_new (hev_config_get_listen_address (),
+    /* Build array of listen addresses */
+    hev_config_get_listen_address (&addr_count);
+    addrs = hev_malloc0 (sizeof (const char *) * addr_count);
+    if (!addrs) {
+        LOG_E ("socks5 proxy addresses alloc");
+        goto exit;
+    }
+    for (i = 0; i < addr_count; i++) {
+        addrs[i] = hev_config_get_listen_address_at (i);
+    }
+
+    factory = hev_socket_factory_new (addrs, addr_count,
                                       hev_config_get_listen_port (),
                                       hev_config_get_listen_ipv6_only ());
+    hev_free (addrs);
     if (!factory) {
         LOG_E ("socks5 proxy socket factory");
         goto exit;

--- a/src/hev-socks5-worker.c
+++ b/src/hev-socks5-worker.c
@@ -237,8 +237,7 @@ hev_socks5_worker_init (HevSocks5Worker *self, const int *fds,
 
     LOG_D ("%p works worker init", self);
 
-    if (!fds || fd_count == 0 ||
-        fd_count > HEV_CONFIG_MAX_LISTEN_ADDRESSES)
+    if (!fds || fd_count == 0 || fd_count > HEV_CONFIG_MAX_LISTEN_ADDRESSES)
         return -1;
 
     self->task_event = hev_task_new (-1);

--- a/src/hev-socks5-worker.c
+++ b/src/hev-socks5-worker.c
@@ -19,6 +19,7 @@
 #include <hev-memory-allocator.h>
 
 #include "hev-config.h"
+#include "hev-config-const.h"
 #include "hev-logger.h"
 #include "hev-compiler.h"
 #include "hev-socks5-session.h"
@@ -33,14 +34,14 @@ typedef struct _HevSocks5WorkerTaskData
 
 struct _HevSocks5Worker
 {
-    int fds[16];
+    int fds[HEV_CONFIG_MAX_LISTEN_ADDRESSES];
     int quit;
     unsigned int fd_count;
     int event_fds[2];
 
     HevTask *task_event;
-    HevTask *task_workers[16];
-    HevSocks5WorkerTaskData task_datas[16];
+    HevTask *task_workers[HEV_CONFIG_MAX_LISTEN_ADDRESSES];
+    HevSocks5WorkerTaskData task_datas[HEV_CONFIG_MAX_LISTEN_ADDRESSES];
     HevList session_set;
     HevSocks5Authenticator *auth_curr;
     HevSocks5Authenticator *auth_next;
@@ -236,7 +237,8 @@ hev_socks5_worker_init (HevSocks5Worker *self, const int *fds,
 
     LOG_D ("%p works worker init", self);
 
-    if (!fds || fd_count == 0 || fd_count > 16)
+    if (!fds || fd_count == 0 ||
+        fd_count > HEV_CONFIG_MAX_LISTEN_ADDRESSES)
         return -1;
 
     self->task_event = hev_task_new (-1);

--- a/src/hev-socks5-worker.c
+++ b/src/hev-socks5-worker.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <stdatomic.h>
 
@@ -24,14 +25,22 @@
 
 #include "hev-socks5-worker.h"
 
+typedef struct _HevSocks5WorkerTaskData
+{
+    HevSocks5Worker *worker;
+    int fd;
+} HevSocks5WorkerTaskData;
+
 struct _HevSocks5Worker
 {
-    int fd;
+    int fds[16];
     int quit;
+    unsigned int fd_count;
     int event_fds[2];
 
     HevTask *task_event;
-    HevTask *task_worker;
+    HevTask *task_workers[16];
+    HevSocks5WorkerTaskData task_datas[16];
     HevList session_set;
     HevSocks5Authenticator *auth_curr;
     HevSocks5Authenticator *auth_next;
@@ -81,15 +90,15 @@ hev_socks5_session_task_entry (void *data)
 static void
 hev_socks5_worker_task_entry (void *data)
 {
+    HevSocks5WorkerTaskData *tdata = data;
     HevTask *task = hev_task_self ();
-    HevSocks5Worker *self = data;
+    HevSocks5Worker *self = tdata->worker;
     HevListNode *node;
     int stack_size;
-    int fd;
+    int fd = tdata->fd;
 
     LOG_D ("socks5 worker task run");
 
-    fd = self->fd;
     hev_task_add_fd (task, fd, POLLIN);
     stack_size = hev_config_get_misc_task_stack_size ();
 
@@ -170,7 +179,8 @@ hev_socks5_event_task_entry (void *data)
     }
 
     self->quit = 1;
-    hev_task_wakeup (self->task_worker);
+    for (unsigned int i = 0; i < self->fd_count; i++)
+        hev_task_wakeup (self->task_workers[i]);
 
     hev_task_del_fd (task, self->event_fds[0]);
     close (self->event_fds[0]);
@@ -188,7 +198,7 @@ hev_socks5_worker_new (void)
 
     LOG_D ("%p socks5 worker new", self);
 
-    self->fd = -1;
+    memset (self->fds, -1, sizeof (self->fds));
     self->event_fds[0] = -1;
     self->event_fds[1] = -1;
 
@@ -205,31 +215,59 @@ hev_socks5_worker_destroy (HevSocks5Worker *self)
     if (self->auth_next)
         hev_object_unref (HEV_OBJECT (self->auth_next));
 
-    if (self->fd >= 0)
-        close (self->fd);
+    if (self->task_event)
+        hev_task_unref (self->task_event);
+
+    for (unsigned int i = 0; i < self->fd_count; i++) {
+        if (self->task_workers[i])
+            hev_task_unref (self->task_workers[i]);
+        if (self->fds[i] >= 0)
+            close (self->fds[i]);
+    }
 
     free (self);
 }
 
 int
-hev_socks5_worker_init (HevSocks5Worker *self, int fd)
+hev_socks5_worker_init (HevSocks5Worker *self, const int *fds,
+                        unsigned int fd_count)
 {
+    unsigned int i;
+
     LOG_D ("%p works worker init", self);
 
-    self->task_worker = hev_task_new (-1);
-    if (!self->task_worker) {
-        LOG_E ("socks5 worker task worker");
+    if (!fds || fd_count == 0 || fd_count > 16)
         return -1;
-    }
 
     self->task_event = hev_task_new (-1);
     if (!self->task_event) {
         LOG_E ("socks5 worker task event");
-        hev_task_unref (self->task_worker);
         return -1;
     }
 
-    self->fd = fd;
+    for (i = 0; i < fd_count; i++) {
+        self->task_workers[i] = hev_task_new (-1);
+        if (!self->task_workers[i]) {
+            unsigned int j;
+
+            LOG_E ("socks5 worker task worker");
+            for (j = 0; j < i; j++) {
+                hev_task_unref (self->task_workers[j]);
+                self->task_workers[j] = NULL;
+                close (self->fds[j]);
+                self->fds[j] = -1;
+            }
+            hev_task_unref (self->task_event);
+            self->task_event = NULL;
+            return -1;
+        }
+
+        self->fds[i] = fds[i];
+        self->task_datas[i].worker = self;
+        self->task_datas[i].fd = fds[i];
+    }
+
+    self->fd_count = fd_count;
 
     return 0;
 }
@@ -240,7 +278,10 @@ hev_socks5_worker_start (HevSocks5Worker *self)
     LOG_D ("%p works worker start", self);
 
     hev_task_run (self->task_event, hev_socks5_event_task_entry, self);
-    hev_task_run (self->task_worker, hev_socks5_worker_task_entry, self);
+    for (unsigned int i = 0; i < self->fd_count; i++) {
+        hev_task_run (self->task_workers[i], hev_socks5_worker_task_entry,
+                      &self->task_datas[i]);
+    }
 }
 
 void

--- a/src/hev-socks5-worker.h
+++ b/src/hev-socks5-worker.h
@@ -16,7 +16,8 @@ typedef struct _HevSocks5Worker HevSocks5Worker;
 
 HevSocks5Worker *hev_socks5_worker_new (void);
 void hev_socks5_worker_destroy (HevSocks5Worker *self);
-int hev_socks5_worker_init (HevSocks5Worker *self, int fd);
+int hev_socks5_worker_init (HevSocks5Worker *self, const int *fds,
+                            unsigned int fd_count);
 
 void hev_socks5_worker_start (HevSocks5Worker *self);
 void hev_socks5_worker_stop (HevSocks5Worker *self);

--- a/src/misc/hev-compiler.h
+++ b/src/misc/hev-compiler.h
@@ -27,7 +27,7 @@ extern "C" {
 #define EXPORT_SYMBOL __attribute__ ((visibility ("default")))
 #endif
 
-#define barrier() __asm__ __volatile__ ("" : : : "memory")
+#define barrier() __asm__ __volatile__("" : : : "memory")
 
 static inline void
 __read_once_size (void *dst, const volatile void *src, int size)

--- a/src/misc/hev-compiler.h
+++ b/src/misc/hev-compiler.h
@@ -27,7 +27,7 @@ extern "C" {
 #define EXPORT_SYMBOL __attribute__ ((visibility ("default")))
 #endif
 
-#define barrier() __asm__ __volatile__("" : : : "memory")
+#define barrier() __asm__ __volatile__ ("" : : : "memory")
 
 static inline void
 __read_once_size (void *dst, const volatile void *src, int size)


### PR DESCRIPTION
This PR implements support for multiple IP addresses in the listen-address configuration option (resolves #15). The listen-address can now be a single string or a YAML list.